### PR TITLE
Build: Add Public Base Path for Static Assets URL

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/pettake-web-ui/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
Add public base path to `vite.config.js` to solve static folder path issue.